### PR TITLE
Gemfile: Lock nokogiri to Ruby 2.6-compatible version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,6 @@ gem 'jekyll', '~> 3.8'
 gem 'jemoji', '~> 0.13'
 gem 'redcarpet', '~> 3.5'
 gem 'pygments.rb', '~> 1.1'
+
+# 1.14.0 is Ruby 2.7 only
+gem 'nokogiri', '< 1.14.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,8 +101,9 @@ DEPENDENCIES
   jekyll-multiple-languages-plugin!
   jekyll-paginate (~> 1.1)
   jemoji (~> 0.13)
+  nokogiri (< 1.14.0)
   pygments.rb (~> 1.1)
   redcarpet (~> 3.5)
 
 BUNDLED WITH
-   2.2.0
+   2.3.20


### PR DESCRIPTION
This paves the way for https://github.com/perlun/perlun.eu.org/pull/40. We could outright upgrade Nokogiri in this PR, but I'll let Dependabot take the credit for that since it was the one who prompted the upgrade in the first place. :)

The problem with https://github.com/perlun/perlun.eu.org/pull/40 as it currently stands is that it tries to use Nokogiri 1.16.0, which has dropped both Ruby 2.6 support (in 1.14.0) and Ruby 2.7 (in 1.16.0). Both of these Ruby versions have reached EOL, so we should certainly upgrade our Ruby version as well but let's begin with addressing these security-related PRs first.